### PR TITLE
Refactored navbar for horizontal viewing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -81,7 +81,7 @@ html {
   }
 }
 
-@media (max-width: 790px) {
+@media (max-width:950px) {
   .App {
     /* Not using vh to allow app to scroll */
     /* Take up full size */

--- a/frontend/src/components/navbar/Navbar.css
+++ b/frontend/src/components/navbar/Navbar.css
@@ -2,7 +2,7 @@
 
 .Navbar {
   width: 100%;
-  height: 55px;
+  height: 75px;
   background-color: #19180a;
   display: flex;
   flex-direction: row;
@@ -43,8 +43,11 @@
   border-radius: 0;
   border: none;
   border-bottom: 3px solid transparent;
-  margin: 10px 5px 0px 5px;
+  margin: 5px;
   text-decoration: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .navBarButton:focus {
@@ -82,7 +85,7 @@
   top: 7px;
 }
 
-@media (max-width: 790px) {
+@media (max-width: 950px) {
   .Navbar {
     flex-direction: column;
     height: 100%;
@@ -117,7 +120,7 @@
 
   .navBarOpen {
     /* transition: 0.5s; */
-    height: 100%;
+    height: 200vh;
   }
 
   .navBarOpen .logo {
@@ -126,7 +129,7 @@
   }
 
   .navBarClosed {
-    transition: 0.2s;
+    /* transition: 0.2s; */
     justify-content: center;
     flex-direction: row;
     height: 75px;

--- a/frontend/src/components/navbar/Navbar.css
+++ b/frontend/src/components/navbar/Navbar.css
@@ -2,7 +2,7 @@
 
 .Navbar {
   width: 100%;
-  height: 75px;
+  height: 55px;
   background-color: #19180a;
   display: flex;
   flex-direction: row;

--- a/frontend/src/components/navbar/Navbar.tsx
+++ b/frontend/src/components/navbar/Navbar.tsx
@@ -8,6 +8,7 @@ import { useHistory } from 'react-router-dom';
 
 function Navbar() {
 
+  const MAX_SCREEN_WIDTH = 950;
 
   const [open, setOpen] = useState(false);
   const [screenSize, SetScreenSize] = useState(window.innerWidth);
@@ -24,7 +25,7 @@ function Navbar() {
 
 
   const handleNavLinkPress = () => {
-    if (screenSize < 791) {
+    if (screenSize < MAX_SCREEN_WIDTH) {
       setOpen(false);
       document.getElementsByClassName('Navbar')[0].classList.toggle('active');
       document.getElementsByClassName('ham')[0].classList.toggle('active');
@@ -42,7 +43,7 @@ function Navbar() {
     <div className={navBarClass}>
 
       <div className="navBarContainer">
-        <span className="logo" onClick={() => history.push('/') }> Findr </span>
+        <span className="logo" onClick={() => {history.push('/'); if (open) handleNavLinkPress(); } }> Findr </span>
         <HamburgerButton open={open} setOpen={(isOpen: boolean): void => { setOpen(isOpen) }} />
       </div>
 

--- a/frontend/src/components/navbar/buttons/HamburgerButton.css
+++ b/frontend/src/components/navbar/buttons/HamburgerButton.css
@@ -159,7 +159,7 @@
   stroke-dashoffset: -64px;
 }
 
-@media (max-width: 790px) {
+@media (max-width: 950px) {
   .hamburgerContainer {
     display: inline;
   }


### PR DESCRIPTION
- Navbar height changed from 55px to 75px for desktop view (inconsistent heights between mobile and desktop)
- styled navbar for horizontal view as well
- media query capped at 950 px (previously 790px) to prevent inner navbar components from colliding
- commented out the 0.2s transition from navBarClosed class for snappier animation
- Added simple logic to navbar Findr logo so that hamburger button and navbar closes when the Findr logo is pressed while the navbar is open
- All NavLinks are still present for testing purposes but in a later commit I can adjust the navlinks to have only the required buttons