### PR TITLE
added css classes in App.css

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -81,7 +81,7 @@ html {
   }
 }
 
-@media (max-width:950px) {
+@media (max-width: 950px) {
   .App {
     /* Not using vh to allow app to scroll */
     /* Take up full size */
@@ -128,6 +128,17 @@ html {
   font-weight: 800;
   margin: 30px;
   text-align: center;
+}
+
+.homepage-subtitle-text {
+  font-size: 30px;
+  font-weight: 700;
+  margin: 15px 0px 10px 0px;
+}
+
+.menu-subtitle-text {
+  font-weight: 800;
+  font-size: 25px;
 }
 
 .error-text {

--- a/frontend/src/components/home/Home.css
+++ b/frontend/src/components/home/Home.css
@@ -1,9 +1,3 @@
-.row-title {
-  font-size: 30px;
-  font-weight: 700;
-  margin: 15px 0px 10px 0px;
-}
-
 .full-container {
   padding: 0px 25px 0px 25px !important;
 }

--- a/frontend/src/components/home/Home.tsx
+++ b/frontend/src/components/home/Home.tsx
@@ -26,7 +26,7 @@ function Home() {
     <Container fluid className="full-container">
       <Row className="home-row-container">
         <Col xs={12} lg={6}>
-          <h1 className="row-title">Just for You</h1>
+          <h1 className="homepage-subtitle-text">Just for You</h1>
           <Row className="home-row">
             <PostCard title="Basketball court with 4 hoops inside the community." location="Grand View-on-Hudson, New York" review={5.0} reviewCount={69} images={tempArray} url="/category-result/sports/subcategory-result/basketball/uuid/example_uuid" />
             <PostCard title="Test" location="Location" review={5.0} reviewCount={69} images={tempArray} />
@@ -38,7 +38,7 @@ function Home() {
         </Col>
 
         <Col xs={12} lg={6}>
-          <h1 className="row-title">Recently Visited  </h1>
+          <h1 className="homepage-subtitle-text">Recently Visited  </h1>
           <Row className="home-row">
             <PostCard title="Basketball court with 4 hoops inside the community." location="Grand View-on-Hudson, New York" review={5.0} reviewCount={69} images={tempArray} />
             <PostCard title="Test" location="Location" review={5.0} reviewCount={69} images={tempArray} />
@@ -51,7 +51,7 @@ function Home() {
 
       <Row className="home-row-container">
         <Col xs={12} lg={6}>
-          <h1 className="row-title">New Categories For You</h1>
+          <h1 className="homepage-subtitle-text">New Categories For You</h1>
           <Row className="home-row">
             <CategoryCard title="Sports" image={basketballImage} url="/category-result/sports" />
             <CategoryCard title="Date" image={'https://images.pexels.com/photos/4255483/pexels-photo-4255483.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260'} />
@@ -63,7 +63,7 @@ function Home() {
         </Col>
 
         <Col xs={12} lg={6}>
-          <h1 className="row-title">Saved Categories </h1>
+          <h1 className="homepage-subtitle-text">Saved Categories </h1>
           <Row className="home-row">
             <CategoryCard title="Sports" image={basketballImage} />
             <CategoryCard title="Date" image={'https://images.pexels.com/photos/4255483/pexels-photo-4255483.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260'} />
@@ -77,7 +77,7 @@ function Home() {
 
       <Row className="home-row-container">
         <Col xs={12} lg={6}>
-          <h1 className="row-title">Top Places</h1>
+          <h1 className="homepage-subtitle-text">Top Places</h1>
           <Row className="home-row">
             <PostCard title="Basketball court with 4 hoops inside the community." location="Grand View-on-Hudson, New York" review={5.0} reviewCount={69} images={tempArray} />
             <PostCard title="Test" location="Location" review={5.0} reviewCount={69} images={tempArray} />
@@ -89,7 +89,7 @@ function Home() {
         </Col>
 
         <Col xs={12} lg={6}>
-          <h1 className="row-title"> Top Categories </h1>
+          <h1 className="homepage-subtitle-text"> Top Categories </h1>
           <Row className="home-row">
             <CategoryCard title="Sports" image={basketballImage} />
             <CategoryCard title="Sports" image={basketballImage} />

--- a/frontend/src/components/menu/categoryResult/CategoryResult.css
+++ b/frontend/src/components/menu/categoryResult/CategoryResult.css
@@ -16,11 +16,6 @@
   flex-direction: row;
 }
 
-.category-result-title {
-  font-weight: 800;
-  font-size: 25px;
-}
-
 .category-result-follow {
   height: inherit;
   display: flex;

--- a/frontend/src/components/menu/categoryResult/CategoryResult.tsx
+++ b/frontend/src/components/menu/categoryResult/CategoryResult.tsx
@@ -35,7 +35,7 @@ function CategoryResult() {
 
                 <div className="category-result-header">
                     <div className="category-result-title-group">
-                        <div className="category-result-title">Basketball</div>
+                        <div className="menu-subtitle-text">Basketball</div>
                         <div className="category-result-follow">Follow</div>
                     </div>
                     <div className="category-result-follow" onClick={() => history.push('/category-result/sports/subcategory-result/basketball')}>View All</div>
@@ -54,7 +54,7 @@ function CategoryResult() {
                     <PostCard title="Test" location="Location" review={5.0} reviewCount={69} images={tempArray} />
                     <div> &nbsp; </div>            </div>            <div className="category-result-header">
                     <div className="category-result-title-group">
-                        <div className="category-result-title">Football</div>
+                        <div className="menu-subtitle-text">Football</div>
                         <div className="category-result-follow">Follow</div>
                     </div>
                     <div className="category-result-follow">View All</div>
@@ -76,7 +76,7 @@ function CategoryResult() {
 
                 <div className="category-result-header">
                     <div className="category-result-title-group">
-                        <div className="category-result-title">Football</div>
+                        <div className="menu-subtitle-text">Football</div>
                         <div className="category-result-follow">Follow</div>
                     </div>
                     <div className="category-result-follow">View All</div>


### PR DESCRIPTION
I've added 2 css classes in App.css that are for the subtitles on the home page and subtitles on our menu pages. If we decide to make more menus or pages, we can reuse these. The home page subtitle is separate since it requires different level of padding compared to the menu pages.

I also think there are other classes that can be made but I don't see any for now. Feel free to comment on some things we can group together but those were the only reusable ones I saw that could be helpful for later.